### PR TITLE
Speed Up Unittests dramatically

### DIFF
--- a/intuitlib/client.py
+++ b/intuitlib/client.py
@@ -51,13 +51,13 @@ class AuthClient(requests.Session):
         self.state_token = state_token
 
         # Discovery doc contains endpoints based on environment specified
-        discovery_doc = get_discovery_doc(self.environment, session=self)
-        self.auth_endpoint = discovery_doc['authorization_endpoint']
-        self.token_endpoint = discovery_doc['token_endpoint']
-        self.revoke_endpoint = discovery_doc['revocation_endpoint']
-        self.issuer_uri = discovery_doc['issuer']
-        self.jwks_uri = discovery_doc['jwks_uri']
-        self.user_info_url = discovery_doc['userinfo_endpoint']
+        self._discovery_doc = None
+        self._auth_endpoint = None
+        self._token_endpoint = None
+        self._revoke_endpoint = None
+        self._issuer_uri = None
+        self._jwks_uri = None
+        self._user_info_url = None
 
         # response values
         self.realm_id = realm_id
@@ -66,7 +66,49 @@ class AuthClient(requests.Session):
         self.refresh_token = refresh_token
         self.x_refresh_token_expires_in = None
         self.id_token = id_token
-        
+    
+    @property
+    def discovery_doc(self):
+        if self._discovery_doc is None:
+            self._discovery_doc = get_discovery_doc(self.environment, session=self)
+        return self._discovery_doc
+
+    @property
+    def auth_endpoint(self):
+        if self._auth_endpoint is None:
+            self._auth_endpoint = self.discovery_doc['authorization_endpoint']
+        return self._auth_endpoint
+
+    @property
+    def token_endpoint(self):
+        if self._token_endpoint is None:
+            self._token_endpoint = self.discovery_doc['token_endpoint']
+        return self._token_endpoint
+
+    @property
+    def revoke_endpoint(self):
+        if self._revoke_endpoint is None:
+            self._revoke_endpoint = self.discovery_doc['revocation_endpoint']
+        return self._revoke_endpoint
+
+    @property
+    def issuer_uri(self):
+        if self._issuer_uri is None:
+            self._issuer_uri = self.discovery_doc['issuer']
+        return self._issuer_uri
+    
+    @property
+    def jwks_uri(self):
+        if self._jwks_uri is None:
+            self._jwks_uri = self.discovery_doc['jwks_uri']
+        return self._jwks_uri
+
+    @property
+    def user_info_url(self):
+        if self._user_info_url is None:
+            self._user_info_url = self.discovery_doc['userinfo_endpoint']
+        return self._user_info_url
+
     def setAuthorizeURLs(self, urlObject):
         """Set authorization url using custom values passed in the data dict
         :param **data: data dict for custom authorizationURLS

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -76,12 +76,12 @@ class TestClient():
         }
         assert auth_params == param_values_to_string
 
-    @mock.patch('intuitlib.utils.requests.Session')
-    def test_exceptions_all_bad_request(self, mock_post, auth_client_default):
+    @mock.patch('intuitlib.utils.requests.Session.request')
+    def test_exceptions_all_bad_request(self, mock_post, auth_client):
         mock_resp = self.mock_request(status=400)
         mock_post.return_value = mock_resp
         
-        auth_client = auth_client_default
+        # auth_client = auth_client_default
         with pytest.raises(AuthClientError):
             auth_client.get_bearer_token('test_code', realm_id='realm')
         

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -31,49 +31,54 @@ from intuitlib.exceptions import AuthClientError
 from intuitlib.migration import migrate
 from tests.helper import MockResponse
 
-class TestMigration():
-    
-    auth_client = AuthClient('clientId','secret','https://www.mydemoapp.com/oauth-redirect','sandbox')
+@pytest.fixture()
+def auth_client_default():
+    return AuthClient('clientId','secret','https://www.mydemoapp.com/oauth-redirect','sandbox')
 
-    client_mock_discovery_urls = {
-        'authorization_endpoint': 'test',
-        'token_endpoint': 'test',
-        'revocation_endpoint': 'test',
-        'issuer': 'test',
-        'jwks_uri': 'test',
-        'userinfo_endpoint': 'test',
+@pytest.fixture()
+def auth_client(auth_client_default):
+    auth_client_default._discovery_doc = {
+        'authorization_endpoint': 'http://test',
+        'token_endpoint': 'http://test',
+        'revocation_endpoint': 'http://test',
+        'issuer': 'http://test',
+        'jwks_uri': 'http://test',
+        'userinfo_endpoint': 'http://test',
     }
+    return auth_client_default
+
+class TestMigration():
 
     def mock_request(self, status=200, content=None):
         return MockResponse(status=status, content=content)
 
     @mock.patch('intuitlib.utils.requests.request')
-    def test_migrate_bad_request(self, mock_post):
+    def test_migrate_bad_request(self, mock_post, auth_client):
         mock_resp = self.mock_request(status=400)
         mock_post.return_value = mock_resp
 
         with pytest.raises(AuthClientError):
-            migrate('consumer_key', 'consumer_secret', 'access_token', 'access_secret', self.auth_client, [Scopes.ACCOUNTING])
+            migrate('consumer_key', 'consumer_secret', 'access_token', 'access_secret', auth_client, [Scopes.ACCOUNTING])
 
     @mock.patch('intuitlib.utils.requests.request')
-    def test_migrate_200(self, mock_post):
+    def test_migrate_200(self, mock_post, auth_client):
         mock_resp = self.mock_request(status=200, content={
             'access_token': 'testaccess'
         })
         mock_post.return_value = mock_resp
 
-        migrate('consumer_key', 'consumer_secret', 'access_token', 'access_secret', self.auth_client, [Scopes.ACCOUNTING])
+        migrate('consumer_key', 'consumer_secret', 'access_token', 'access_secret', auth_client, [Scopes.ACCOUNTING])
 
-        assert self.auth_client.access_token == 'testaccess'
+        assert auth_client.access_token == 'testaccess'
 
     @mock.patch('intuitlib.utils.requests.request')
-    def test_migrate_prod(self, mock_post):
+    def test_migrate_prod(self, mock_post, auth_client):
         mock_resp = self.mock_request(status=400)
         mock_post.return_value = mock_resp
-        self.auth_client.environment = 'production'
+        auth_client.environment = 'production'
 
         with pytest.raises(AuthClientError):
-            migrate('consumer_key', 'consumer_secret', 'access_token', 'access_secret', self.auth_client, [Scopes.ACCOUNTING])
+            migrate('consumer_key', 'consumer_secret', 'access_token', 'access_secret', auth_client, [Scopes.ACCOUNTING])
 
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
This patch addresses Issues #004 and #012. 

This implements a discovery_doc cache so that HTTP requests are not required on the AuthClient constructor. 

This also creates proper fixtures and mocks to be used in the unit tests.   

The testing suite runs extremely fast now and only several HTTP requests are made.  