### PR TITLE
fix(packaging): remove pkg_resources namespace stuff

### DIFF
--- a/intuitlib/__init__.py
+++ b/intuitlib/__init__.py
@@ -12,10 +12,4 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
 
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)
 


### PR DESCRIPTION
Currently poetry is not packaging the actual modules with the build. Its due to the pkg_resources line in __init__

This is odd and really not necessary, unless it is