### PR TITLE
feat(testing): Add HTTP test markers for slow tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ coverage = "^6.5.0"
 pytest-cov = "^4.0.0"
 mock = "^4.0.3"
 
+[tool.pytest.ini_options]
+markers = [
+    "http: marks tests that perform HTTP calls",
+]
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,18 +57,21 @@ class TestUtils():
     def mock_request(self, status=200, content=None):
         return MockResponse(status=status, content=content)
 
+    @pytest.mark.http
     def test_get_discovery_doc_sandbox(self):
         discovery_doc = get_discovery_doc('sandbox')
         
         assert discovery_doc['issuer'] == 'https://oauth.platform.intuit.com/op/v1'
         assert discovery_doc['userinfo_endpoint'] == 'https://sandbox-accounts.platform.intuit.com/v1/openid_connect/userinfo'
 
+    @pytest.mark.http
     def test_get_discovery_doc_production(self):
         discovery_doc = get_discovery_doc('production')
         
         assert discovery_doc['issuer'] == 'https://oauth.platform.intuit.com/op/v1'
         assert discovery_doc['userinfo_endpoint'] == 'https://accounts.platform.intuit.com/v1/openid_connect/userinfo'
 
+    @pytest.mark.http
     def test_get_discovery_doc_custom_url_input(self):
         discovery_doc = get_discovery_doc('https://developer.intuit.com/.well-known/openid_sandbox_configuration/')
         


### PR DESCRIPTION
This patch addresses Issue #018.  A new test marker `http` was added to the project.  

Running `pytest` alone still runs all the slow tests, however you can skip these with `pytest -m "not http"` to run all except these

There might be better ways to skip these tests unless we ask for it.  These are really just checking the response of the Intuit Discovery doc service.  Not something this project needs to test, in reality